### PR TITLE
Use goTo when the link target looks like an ID

### DIFF
--- a/src/renderers/pdf.js
+++ b/src/renderers/pdf.js
@@ -3,6 +3,10 @@ import runDescent from '../run/descent';
 import advanceWidth from '../run/advanceWidth';
 import ascent from '../attributedString/ascent';
 
+const DEST_REGEXP = /^#.+/;
+
+const isSrcId = src => src.match(DEST_REGEXP);
+
 const renderAttachments = (ctx, run) => {
   ctx.save();
 
@@ -55,7 +59,11 @@ const renderRun = (ctx, run, options) => {
   ctx.fillOpacity(opacity);
 
   if (link) {
-    ctx.link(0, -height - descent, runAdvanceWidth, height, link);
+    if (isSrcId(link)) {
+      ctx.goTo(0, -height - descent, runAdvanceWidth, height, link.slice(1));
+    } else {
+      ctx.link(0, -height - descent, runAdvanceWidth, height, link);
+    }
   }
 
   renderAttachments(ctx, run);


### PR DESCRIPTION
As explained in the [last comment](https://github.com/diegomura/react-pdf/issues/1099#issuecomment-767571081) in diegomura/react-pdf#1099, `<Link src="#foo">text</Link>` won't navigate to the target ID in Adobe Acrobat Reader unless it's located right under `<Page />` element, in which case `setLink(node)` will handle the link properly.  When `<Link />` is located elsewhere, the link ends up processed from within `renderRun` in textkit.

Please feel free to modify or create a better version.

Essential part taken from the change in diegomura/react-pdf#746.